### PR TITLE
Change user_id type from numeric to uuid in user router

### DIFF
--- a/backend/api/frontend/serializers.py
+++ b/backend/api/frontend/serializers.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import SerializerMethodField, CharField, DateField, IntegerField
+from rest_framework.fields import SerializerMethodField, CharField, DateField, IntegerField, UUIDField
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.relations import SlugRelatedField
 from rest_framework.serializers import ModelSerializer as DRFModelSerializer, ListSerializer, Serializer
@@ -714,4 +714,4 @@ class ApplicationRouterKwargsSerializer(Serializer):
 
 
 class UserRouterKwargsSerializer(Serializer):
-    user_id = IntegerField()
+    user_id = UUIDField()


### PR DESCRIPTION
This fixes a 400 validation error when sending `GET /api/frontend/users/:user_id/events_where_was_organizer/`

```json
{"user_id":["Je vyžadováno celé číslo."]}
```

I tested it locally and it seems to fix the error. It may be less than optimal - it's my first PR to this repository. So feel free and very welcome to fix any imperfections now, or patch later... 🙂 