### PR TITLE
Point nginx http->https redirect to original url

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,7 +5,9 @@ upstream backend {
 
 
 server {
-    listen 80 default; return 302 https://bis.lomic.cz/;}
+    listen 80 default;
+    return 301 https://$host$request_uri;
+}
 server {
     listen 443 ssl;
     ssl_certificate certs/bis.lomic.cz/fullchain.pem;


### PR DESCRIPTION
Until now, the http://dev.bis.lomic.cz/org/ redirected users to https://bis.lomic.cz.

The nginx config suggested here redirects visitors using http to the same url with https.

(i already pushed it to dev server, so we can try it out)