### PR TITLE
Fix typo in health insurance company CZPZ -> CPZP

### DIFF
--- a/backend/bis/management/commands/create_init_data.py
+++ b/backend/bis/management/commands/create_init_data.py
@@ -192,7 +192,7 @@ class Command(BaseCommand):
             name='Všeobecná zdravotní pojišťovna České republiky'))
         HealthInsuranceCompany.objects.update_or_create(slug='VOZP', defaults=dict(
             name='Vojenská zdravotní pojišťovna České republiky'))
-        HealthInsuranceCompany.objects.update_or_create(slug='CZPZ', defaults=dict(
+        HealthInsuranceCompany.objects.update_or_create(slug='CPZP', defaults=dict(
             name='Česká průmyslová zdravotní pojišťovna'))
         HealthInsuranceCompany.objects.update_or_create(slug='OZP', defaults=dict(
             name='Oborová zdravotní pojišťovna zaměstnanců bank, pojišťoven a stavebnictví'))


### PR DESCRIPTION
More text in description than actual change... :)

feel free to merge if useful @lamanchy 

(we may actually need it correct for matching user input (import of event participants from excel) to id)